### PR TITLE
update readme with CLI usage and local Webhook documentation

### DIFF
--- a/firestore-stripe-payments/README.md
+++ b/firestore-stripe-payments/README.md
@@ -50,6 +50,16 @@ Then, in the [Stripe Dashboard](https://dashboard.stripe.com):
 
 - Create a new [restricted key](https://stripe.com/docs/keys#limit-access) with write access for the "Customers", "Checkout Sessions" and "Customer portal" resources, and read-only access for the "Subscriptions" and "Prices" resources.
 
+#### Installing via Firebase CLI
+
+When installing via the CLI, be sure to pin the version. 
+
+```
+firebase ext:install stripe/firestore-stripe-payments@0.3.1 --project=projectId_or_alias
+```
+
+The current version can be found in [extension.yaml](extension.yaml). 
+
 #### Billing
 
 This extension uses the following Firebase services which may have associated charges:

--- a/firestore-stripe-payments/README.md
+++ b/firestore-stripe-payments/README.md
@@ -55,7 +55,11 @@ Then, in the [Stripe Dashboard](https://dashboard.stripe.com):
 When installing via the CLI, be sure to pin the version. 
 
 ```
-firebase ext:install stripe/firestore-stripe-payments@0.3.1 --project=projectId_or_alias
+firebase ext:install invertase/firestore-stripe-payments --project=projectId_or_alias
+
+Alternatively for local source:
+
+firebase ext:install . --project=projectId_or_alias
 ```
 
 The current version can be found in [extension.yaml](extension.yaml). 

--- a/firestore-stripe-payments/README.md
+++ b/firestore-stripe-payments/README.md
@@ -73,7 +73,7 @@ Be sure to configure your test mode [API Key](https://stripe.com/docs/keys) and 
 Start the firebase emulator with:
 
 ```
-firebase emulators:start
+firebase emulators:start --project=projectId_or_alias
 ```
 
 Find the functions path associated with the stripe extension, typically it looks like this:

--- a/firestore-stripe-payments/README.md
+++ b/firestore-stripe-payments/README.md
@@ -50,7 +50,7 @@ Then, in the [Stripe Dashboard](https://dashboard.stripe.com):
 
 - Create a new [restricted key](https://stripe.com/docs/keys#limit-access) with write access for the "Customers", "Checkout Sessions" and "Customer portal" resources, and read-only access for the "Subscriptions" and "Prices" resources.
 
-#### Installing via Firebase CLI
+#### Installing via Firebase CLI 
 
 When installing via the CLI, be sure to pin the version. 
 
@@ -59,6 +59,33 @@ firebase ext:install stripe/firestore-stripe-payments@0.3.1 --project=projectId_
 ```
 
 The current version can be found in [extension.yaml](extension.yaml). 
+
+#### Using webhooks locally
+
+If you wish to test the webhooks **locally**, use the following command to configure the extension:
+
+```
+firebase ext:configure firestore-stripe-payments --local
+```
+
+Be sure to configure your test mode [API Key](https://stripe.com/docs/keys) and webhook [signing secret](https://stripe.com/docs/webhooks/signatures#:~:text=Before%20you%20can%20verify%20signatures,secret%20key%20for%20each%20endpoint.) when prompted. 
+
+Start the firebase emulator with:
+
+```
+firebase emulators:start
+```
+
+Find the functions path associated with the stripe extension, typically it looks like this:
+
+`http://localhost:3999/{projectId}/{region}/ext-firestore-stripe-payments-handleWebhookEvents`
+
+
+You can tunnel your local endpoint using a tool like [ngrok](https://ngrok.com/). In this case you will tunnel the localhost domain and port `http://localhost:3999`. Replace `localhost:3999` with your tunnel url. The end result would look something like `https://1234-1234-1234.ngrok.io/{projectId}/{region}/ext-firestore-stripe-payments-handleWebhookEvents`
+
+Configure your test mode stripe [webhook endpoint](https://stripe.com/docs/webhooks) with the url you just constructed. 
+
+Your local webhooks are now set up. 
 
 #### Billing
 

--- a/firestore-stripe-payments/README.md
+++ b/firestore-stripe-payments/README.md
@@ -80,7 +80,7 @@ Find the functions path associated with the stripe extension, typically it looks
 
 - `http://192.0.0.1:5001/{projectId}/{region}/ext-firestore-stripe-payments-handleWebhookEvents`
 
-- You can tunnel your local endpoint using a tool like [ngrok](https://ngrok.com/). In this case you will tunnel the localhost domain and port `http://localhost:3999`. Replace `localhost:3999` with your tunnel url. The end result would look something like:
+- You can tunnel your local endpoint using a tool like [ngrok](https://ngrok.com/). In this case you will tunnel the localhost domain and port `http://127.0.01:5001`. Replace `127.0.0.1:5001` with your tunnel url. The end result would look something like:
 
 ```
 https://1234-1234-1234.ngrok.io/{projectId}/{region}/ext-firestore-stripe-payments-handleWebhookEvents

--- a/firestore-stripe-payments/README.md
+++ b/firestore-stripe-payments/README.md
@@ -78,14 +78,17 @@ firebase emulators:start
 
 Find the functions path associated with the stripe extension, typically it looks like this:
 
-`http://localhost:3999/{projectId}/{region}/ext-firestore-stripe-payments-handleWebhookEvents`
+- `http://localhost:3999/{projectId}/{region}/ext-firestore-stripe-payments-handleWebhookEvents`
 
+- You can tunnel your local endpoint using a tool like [ngrok](https://ngrok.com/). In this case you will tunnel the localhost domain and port `http://localhost:3999`. Replace `localhost:3999` with your tunnel url. The end result would look something like:
 
-You can tunnel your local endpoint using a tool like [ngrok](https://ngrok.com/). In this case you will tunnel the localhost domain and port `http://localhost:3999`. Replace `localhost:3999` with your tunnel url. The end result would look something like `https://1234-1234-1234.ngrok.io/{projectId}/{region}/ext-firestore-stripe-payments-handleWebhookEvents`
+```
+https://1234-1234-1234.ngrok.io/{projectId}/{region}/ext-firestore-stripe-payments-handleWebhookEvents
+```
 
-Configure your test mode stripe [webhook endpoint](https://stripe.com/docs/webhooks) with the url you just constructed. 
+- Configure your test mode stripe [webhook endpoint](https://stripe.com/docs/webhooks) with the url you just constructed. 
 
-Your local webhooks are now set up. 
+- Your local webhooks are now set up. 
 
 #### Billing
 

--- a/firestore-stripe-payments/README.md
+++ b/firestore-stripe-payments/README.md
@@ -78,7 +78,7 @@ firebase emulators:start --project=projectId_or_alias
 
 Find the functions path associated with the stripe extension, typically it looks like this:
 
-- `http://localhost:3999/{projectId}/{region}/ext-firestore-stripe-payments-handleWebhookEvents`
+- `http://192.0.0.1:5001/{projectId}/{region}/ext-firestore-stripe-payments-handleWebhookEvents`
 
 - You can tunnel your local endpoint using a tool like [ngrok](https://ngrok.com/). In this case you will tunnel the localhost domain and port `http://localhost:3999`. Replace `localhost:3999` with your tunnel url. The end result would look something like:
 


### PR DESCRIPTION
Hi team at Stripe!

Using this command from the [firebase docs](https://firebase.google.com/products/extensions/stripe-firestore-stripe-payments) does not seem to work for me:
```
firebase ext:install stripe/firestore-stripe-payments --local --project=projectId_or_alias
```

I wanted to open this because it caused some headaches until I found the error has to do with the version ref not being supplied with that command:  https://github.com/stripe/stripe-firebase-extensions/issues/394

I presume this would be a temporary solution, but should hopefully give other devs more info when trying to set up things via the CLI. The firebase CLI should theoretically be able to pull the version in the payload shown when running the command in debug mode:

```
,"spec":{"specVersion":"v1beta","name":"firestore-stripe-payments","version":"0.3.1"
```
However, this seems like a FB CLI issue, not exactly a stripe issue. 