### PR TITLE
Update comment for one-time payment

### DIFF
--- a/firestore-stripe-payments/functions/src/index.ts
+++ b/firestore-stripe-payments/functions/src/index.ts
@@ -662,7 +662,7 @@ const insertPaymentRecord = async (
     payment['prices'] = prices;
     payment['items'] = lineItems.data;
   }
-  // Write to invoice to a subcollection on the subscription doc.
+  // Write to invoice to a subcollection on the customer doc.
   await customersSnap.docs[0].ref
     .collection('payments')
     .doc(payment.id)


### PR DESCRIPTION
This comments refers to a subcollection on subscription doc, but I think it should ref to the customer doc.

We aren't writing to subscription, but to customer. 

This came up because I'm not using subscriptions but do want to use this to sync payments on one-time purchases (via checkout_session and/or manual invoices)

Overall, it seems like this extension assumes invoice == subscription. Which is fine. I'll just handle certain webhook events outside of this extension. But this is an area where it seems like we can decouple things nicely (FWIW)