### PR TITLE
feat(firestore-stripe-payments): Support `payment_method_collection` parameter

### DIFF
--- a/firestore-stripe-payments/functions/src/index.ts
+++ b/firestore-stripe-payments/functions/src/index.ts
@@ -144,6 +144,7 @@ exports.createCheckoutSession = functions
       consent_collection = {},
       expires_at,
       phone_number_collection = {},
+      payment_method_collection = 'always'
     } = snap.data();
     try {
       logs.creatingCheckoutSession(context.params.id);
@@ -202,6 +203,7 @@ exports.createCheckoutSession = functions
           sessionCreateParams.payment_method_types = payment_method_types;
         }
         if (mode === 'subscription') {
+          sessionCreateParams.payment_method_collection = payment_method_collection
           sessionCreateParams.subscription_data = {
             trial_from_plan,
             metadata,


### PR DESCRIPTION
Enables [free trials without payment details](https://stripe.com/docs/payments/checkout/free-trials) by passing `payment_method_collection` [parameter](https://stripe.com/docs/api/checkout/sessions/create#create_checkout_session-payment_method_collection) when creating `mode: 'subscription'` sessions.

fixes: #476 