### PR TITLE
add invoice_creation prop for one-time payment

### DIFF
--- a/firestore-stripe-payments/functions/src/index.ts
+++ b/firestore-stripe-payments/functions/src/index.ts
@@ -128,6 +128,7 @@ exports.createCheckoutSession = functions
       metadata = {},
       automatic_payment_methods = { enabled: true },
       automatic_tax = false,
+      invoice_creation = false,
       tax_rates = [],
       tax_id_collection = false,
       allow_promotion_codes = false,
@@ -213,6 +214,11 @@ exports.createCheckoutSession = functions
           sessionCreateParams.payment_intent_data = {
             metadata,
             ...(setup_future_usage && { setup_future_usage }),
+          };
+          if (invoice_creation) {
+            sessionCreateParams.invoice_creation = {
+              enabled: true,
+            };
           };
         }
         if (automatic_tax) {


### PR DESCRIPTION
Hi! This pull request is regarding the #489 issue that we are facing in my company.

:baby:  I have read the [contributing guidelines](https://github.com/stripe/stripe-firebase-extensions/blob/98c97775d54fb0be4601864b74d2fe5ce24dab83/CONTRIBUTING.md) and [code of conduct](url) but it is my first contribution so feel free to mention me any omission.

I don't know how to test but I followed [Stripe documentation](https://stripe.com/docs/payments/checkout/post-payment-invoices) and [Stripe API documentation](https://stripe.com/docs/api/checkout/sessions/create#create_checkout_session-invoice_creation).

Added the param invoice_creation.enabled to checkout params, using invoice_creation prop (boolean).

Thanks!

fixes: https://github.com/invertase/stripe-firebase-extensions/issues/489