### PR TITLE
Support `flow_data` parameter in `createPortalLink` function

### DIFF
--- a/firestore-stripe-payments/functions/src/index.ts
+++ b/firestore-stripe-payments/functions/src/index.ts
@@ -338,7 +338,13 @@ export const createPortalLink = functions.https.onCall(
       );
     }
     try {
-      const { returnUrl: return_url, locale = 'auto', configuration } = data;
+      const {
+        returnUrl: return_url,
+        locale = 'auto',
+        configuration,
+        flow_data,
+      } = data;
+
       // Get stripe customer id
       const customer = (
         await admin
@@ -354,6 +360,12 @@ export const createPortalLink = functions.https.onCall(
       };
       if (configuration) {
         params.configuration = configuration;
+      }
+      if (flow_data) {
+        // Ignore type-checking because `flow_data` was added to
+        // `Stripe.BillingPortal.SessionCreateParams` in
+        // stripe@11.2.0 (API version 2022-12-06)
+        (params as any).flow_data = flow_data;
       }
       const session = await stripe.billingPortal.sessions.create(params);
       logs.createdBillingPortalLink(uid);


### PR DESCRIPTION
Resolves #551

Example usage to create a portal link that asks the customer to confirm an amendment to the price and/or quanity of a subscription:

```ts
import { getFunctions, httpsCallable } from 'firebase/functions';

const flow_data = {
  type: 'subscription_update_confirm',
  subscription_update_confirm: {
    subscription: 'sub_XXXXXX',
    items: [
      { id: 'si_XXXXXX', quantity: 4, price: 'price_XXXXXX' },
    ],
  },
};

const portalLinkUrl = (await httpsCallable(getFunctions(app), 'createPortalLink')({ flow_data })).data.url;
```
