### PR TITLE
feat:  add "feature" attribute to firestore product attribute

### DIFF
--- a/firestore-stripe-payments/functions/src/index.ts
+++ b/firestore-stripe-payments/functions/src/index.ts
@@ -437,6 +437,7 @@ const createProductRecord = async (product: Stripe.Product): Promise<void> => {
     images: product.images,
     metadata: product.metadata,
     tax_code: product.tax_code ?? null,
+    features: product.features ?? null,  
     ...prefixMetadata(rawMetadata),
   };
   await admin


### PR DESCRIPTION
createProductRecord will now also save feature attribute if it's not null.  This was missing from the current function, which would be useful when creating pricing tables.  "Feature" attribute is passed in the stripe webhook.