### PR TITLE
fix(types): add trial_period_days to createCheckoutSession options

### DIFF
--- a/firestore-stripe-web-sdk/src/session.ts
+++ b/firestore-stripe-web-sdk/src/session.ts
@@ -102,6 +102,10 @@ export interface CommonSessionCreateParams {
    * to `true`.
    */
   trial_from_plan?: boolean;
+
+  /* Specifies the duration of the trial period in days. Overrides the default on the pricing plan.*/
+
+  trial_period_days?: number,
 }
 
 /**


### PR DESCRIPTION
Adds missing `trial_period_days` field to `CommonSessionCreateParams` in the client SDK.

This resolves a false-positive TypeScript error when using the `createCheckoutSession` function with a trial period, even though the backend supports it as of commit e9ee79e (January 2024).

This change improves developer experience by aligning the client-side types with the backend implementation and avoiding misleading IDE or build-time errors.