### PR TITLE
Proper error handling/return code.

### DIFF
--- a/firestore-stripe-payments/functions/src/index.ts
+++ b/firestore-stripe-payments/functions/src/index.ts
@@ -875,9 +875,7 @@ export const handleWebhookEvents = functions.handler.https.onRequest(
         logs.webhookHandlerSucceeded(event.id, event.type);
       } catch (error) {
         logs.webhookHandlerError(error, event.id, event.type);
-        resp.json({
-          error: 'Webhook handler failed. View function logs in Firebase.',
-        });
+        resp.status(500).send('Webhook handler failed. View function logs in Firebase.');
         return;
       }
     }


### PR DESCRIPTION
When Stripe sends an event to the webhook that this Stripe Payments Firebase extension creates (e.g. "https://us-central1-abcdefg.cloudfunctions.net/ext-firestore-stripe-payments-handleWebhookEvents"), and if an error happens, then the code returns to Stripe a success http status code (200). This is problematic because Stripe thinks that the webhook succeeded.

When the webhook fails with an example error message "An error occurred with our connection to Stripe" (like in my case), then I would rather Stripe know that it failed with the 500 internal server error status code so that it can properly do a retry process, rather than swallow it and forget about it.  Without this PR code change, I would have to not use the extension, and write my own event handlers so that I can properly handle errors on the Stripe side of things.

The logic should ideally be:
1. Error happens -> Tell Stripe it was an error with an error status code like a 500.
2. Error doesn't happen -> Return a 200 success status.

This addresses that.

![image](https://github.com/user-attachments/assets/55b8ada7-0437-4829-98d2-f4179799ed82)
